### PR TITLE
BUG: Added a class named shapepcalib 

### DIFF
--- a/ShapeVariationAnalyzer/shapepcalib.py
+++ b/ShapeVariationAnalyzer/shapepcalib.py
@@ -1036,3 +1036,7 @@ class pcaExplorer:
 	    return colors
 	
 
+class shapepcalib:
+	def __init__(self,e=None):
+		pass
+		


### PR DESCRIPTION
Added a class named shapepcalib in shapepcalib.py to prevent an error message while loading the module.