### PR TITLE
COMP: Fix installation of python packages on windows

### DIFF
--- a/SuperBuild/External_python-ShapeVariationAnalyzer-requirements.cmake
+++ b/SuperBuild/External_python-ShapeVariationAnalyzer-requirements.cmake
@@ -58,7 +58,12 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   if(NOT Slicer_SOURCE_DIR)
     # Alternative python prefix for installing extension python packages
     set(python_packages_DIR "${CMAKE_BINARY_DIR}/python-packages-install")
+
+    # Convert to native path to satisfy pip install command
     file(TO_NATIVE_PATH ${python_packages_DIR} python_packages_DIR_NATIVE_DIR)
+
+    # Escape command argument for pip install command
+    string(REGEX REPLACE "\\\\" "\\\\\\\\" python_packages_DIR_NATIVE_DIR "${python_packages_DIR_NATIVE_DIR}")
 
     list(APPEND pip_install_args
       --prefix ${python_packages_DIR_NATIVE_DIR}


### PR DESCRIPTION
This commit fixes the following error:

```
   Performing install step for 'python-ShapeVariationAnalyzer-requirements'
    CMake Error at D:/D/P/S-0-E-b/ShapeVariationAnalyzer-build/python-ShapeVariationAnalyzer-requirements-prefix/src/pyth
    on-ShapeVariationAnalyzer-requirements-stamp/python-ShapeVariationAnalyzer-requirements-install-Release.cmake:4 (set)
    :
      Syntax error in cmake code at

        D:/D/P/S-0-E-b/ShapeVariationAnalyzer-build/python-ShapeVariationAnalyzer-requirements-prefix/src/python-ShapeVar
    iationAnalyzer-requirements-stamp/python-ShapeVariationAnalyzer-requirements-install-Release.cmake:4

      when parsing string

        D:/D/P/Slicer-0-build/python-install/bin/PythonSlicer.exe;-m;pip;install;--require-hashes;-r;D:/D/P/S-0-E-b/Shape
    VariationAnalyzer-build/python-ShapeVariationAnalyzer-requirements-requirements.txt;--prefix;D:\D\P\S-0-E-b\ShapeVari
    ationAnalyzer-build\python-packages-install

      Invalid character escape '\D'.
```