### PR TITLE
Update list of python requirements to support python 3.9 instead of 3.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,30 @@ set(ShapeVariationAnalyzer_VERSION_MINOR 0)
 set(ShapeVariationAnalyzer_VERSION_PATCH 4)
 
 
-option(ShapeVariationAnalyzer_BUILD_SLICER_EXTENSION OFF)
+#-----------------------------------------------------------------------------
+# Standalone vs Slicer extension option
+#-----------------------------------------------------------------------------
+
+# This option should be named after the project name, it corresponds to the
+# option set to ON when the project is build by the Slicer Extension build
+# system.
+
+set(_default OFF)
+set(_reason "${PROJECT_NAME}_BUILD_SLICER_EXTENSION is ON")
+if(NOT DEFINED ${PROJECT_NAME}_BUILD_SLICER_EXTENSION AND DEFINED Slicer_DIR)
+  set(_default ON)
+  set(_reason "Slicer_DIR is SET")
+endif()
+
+option(${PROJECT_NAME}_BUILD_SLICER_EXTENSION "Build as a Slicer Extension" ${_default})
+
+set(_msg "Checking if building as a Slicer extension")
+message(STATUS ${_msg})
+if(${PROJECT_NAME}_BUILD_SLICER_EXTENSION)
+  message(STATUS "${_msg} - yes (${_reason})")
+else()
+  message(STATUS "${_msg} - no (${PROJECT_NAME}_BUILD_SLICER_EXTENSION is OFF)")
+endif()
 
 if(ShapeVariationAnalyzer_BUILD_SLICER_EXTENSION)
   #-----------------------------------------------------------------------------

--- a/SuperBuild/External_python-ShapeVariationAnalyzer-requirements.cmake
+++ b/SuperBuild/External_python-ShapeVariationAnalyzer-requirements.cmake
@@ -43,19 +43,25 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [joblib]
-  joblib==0.16.0 --hash=sha256:d348c5d4ae31496b2aa060d6d9b787864dd204f9480baaa52d18850cb43e9f49
+  joblib==1.1.0 --hash=sha256:f21f109b3c7ff9d95f8387f752d0d9c34a02aa2f7060c2135f465da0e5160ff6
   # [/joblib]
   # [threadpoolctl]
-  threadpoolctl==2.1.0 --hash=sha256:38b74ca20ff3bb42caca8b00055111d74159ee95c4370882bbff2b93d24da725
+  threadpoolctl==3.1.0 --hash=sha256:8b99adda265feb6773280df41eece7b2e6561b772d21ffd52e372f999024907b
   # [/threadpoolctl]
   # [scikit-learn]
   # Hashes correspond to the following packages:
-  # - scikit_learn-0.23.1-cp36-cp36m-win_amd64.whl
-  # - scikit_learn-0.23.1-cp36-cp36m-macosx_10_9_x86_64.whl 
-  # - scikit_learn-0.23.1-cp36-cp36m-manylinux1_x86_64.whl
-  scikit-learn==0.23.1 --hash=sha256:e585682e37f2faa81ad6cd4472fff646bf2fd0542147bec93697a905db8e6bd2 \
-                       --hash=sha256:058d213092de4384710137af1300ed0ff030b8c40459a6c6f73c31ccd274cc39 \
-                       --hash=sha256:e9879ba9e64ec3add41bf201e06034162f853652ef4849b361d73b0deb3153ad
+  #  - scikit_learn-1.0.2-cp39-cp39-macosx_10_13_x86_64.whl
+  #  - scikit_learn-1.0.2-cp39-cp39-macosx_12_0_arm64.whl
+  #  - scikit_learn-1.0.2-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+  #  - scikit_learn-1.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - scikit_learn-1.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - scikit_learn-1.0.2-cp39-cp39-win_amd64.whl
+  scikit-learn==1.0.2 --hash=sha256:a90b60048f9ffdd962d2ad2fb16367a87ac34d76e02550968719eb7b5716fd10 \
+                      --hash=sha256:7a93c1292799620df90348800d5ac06f3794c1316ca247525fa31169f6d25855 \
+                      --hash=sha256:55f2f3a8414e14fbee03782f9fe16cca0f141d639d2b1c1a36779fa069e1db57 \
+                      --hash=sha256:80095a1e4b93bd33261ef03b9bc86d6db649f988ea4dbcf7110d0cded8d7213d \
+                      --hash=sha256:ff746a69ff2ef25f62b36338c615dd15954ddc3ab8e73530237dd73235e76d62 \
+                      --hash=sha256:b54a62c6e318ddbfa7d22c383466d38d2ee770ebdb5ddb668d56a099f6eaf75f
   # [/scikit-learn]
   ]===])
 

--- a/SuperBuild/External_python-ShapeVariationAnalyzer-requirements.cmake
+++ b/SuperBuild/External_python-ShapeVariationAnalyzer-requirements.cmake
@@ -42,8 +42,13 @@ if(NOT Slicer_USE_SYSTEM_${proj})
 
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
+  # [joblib]
   joblib==0.16.0 --hash=sha256:d348c5d4ae31496b2aa060d6d9b787864dd204f9480baaa52d18850cb43e9f49
+  # [/joblib]
+  # [threadpoolctl]
   threadpoolctl==2.1.0 --hash=sha256:38b74ca20ff3bb42caca8b00055111d74159ee95c4370882bbff2b93d24da725
+  # [/threadpoolctl]
+  # [scikit-learn]
   # Hashes correspond to the following packages:
   # - scikit_learn-0.23.1-cp36-cp36m-win_amd64.whl
   # - scikit_learn-0.23.1-cp36-cp36m-macosx_10_9_x86_64.whl 
@@ -51,6 +56,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   scikit-learn==0.23.1 --hash=sha256:e585682e37f2faa81ad6cd4472fff646bf2fd0542147bec93697a905db8e6bd2 \
                        --hash=sha256:058d213092de4384710137af1300ed0ff030b8c40459a6c6f73c31ccd274cc39 \
                        --hash=sha256:e9879ba9e64ec3add41bf201e06034162f853652ef4849b361d73b0deb3153ad
+  # [/scikit-learn]
   ]===])
 
   set(pip_install_args)


### PR DESCRIPTION
This commit fixes the following build error:

```
  Command failed: 1

   '/Volumes/D/P/S-0-build/python-install/bin/PythonSlicer' '-m' 'pip' 'install' '--require-hashes' '-r' '/.../ShapeVariationAnalyzer-build/python-ShapeVariationAnalyzer-requirements-requirements.txt' '--prefix' '/.../ShapeVariationAnalyzer-build/python-packages-install'

  See also

    /.../ShapeVariationAnalyzer-build/python-ShapeVariationAnalyzer-requirements-prefix/src/python-ShapeVariationAnalyzer-requirements-stamp/python-ShapeVariationAnalyzer-requirements-install-*.log
```

The updates was performed following these steps using the updated
"python_package_updater.py" script assocated with PR Slicer/Slicer#6300:

```
# Set common variables
SLICER_SOURCE_DIR=~/Projects/Slicer
SLICER_DIR=~/Projects/Slicer-Release/Slicer-build
PYTHONSLICER_EXECUTABLE=${SLICER_DIR}/../python-install/bin/PythonSlicer

EXTENSION_SOURCE_DIR=/home/jcfr/Projects/ShapeVariationAnalyzer
EXTENSION_BINARY_DIR=/home/jcfr/Projects/ShapeVariationAnalyzer-Release

# Install packages into the prefix
PYTHON_INSTALL_PREFIX=${EXTENSION_BINARY_DIR}/python-packages-install
${PYTHONSLICER_EXECUTABLE} -m pip install --prefix ${PYTHON_INSTALL_PREFIX} scikit_learn

# Update extension external projects
UPDATER_SCRIPT=${SLICER_SOURCE_DIR}/Utilities/Scripts/python_package_updater.py


${PYTHONSLICER_EXECUTABLE} ${UPDATER_SCRIPT} \
  -s ${EXTENSION_SOURCE_DIR}/SuperBuild      \
  --from-installed-packages \
  --path ${PYTHON_INSTALL_PREFIX}/lib/python3.9/site-packages
```

This addresses the issue initiated here: https://github.com/DCBIA-OrthoLab/ShapeVariationAnalyzer/issues/55