### PR TITLE
COMP: VTK 9.6 Build Fix - Fix iostream include hygiene

### DIFF
--- a/CLI/ComputeMeanShapes/computeMean.hxx
+++ b/CLI/ComputeMeanShapes/computeMean.hxx
@@ -1,5 +1,7 @@
 #include "computeMean.h"
 
+#include <iostream>
+
 
 
 vtkStandardNewMacro(ComputeMean);

--- a/CLI/SurfaceFeaturesExtractor/surfacefeaturesextractor.cxx
+++ b/CLI/SurfaceFeaturesExtractor/surfacefeaturesextractor.cxx
@@ -4,6 +4,7 @@
 #include <vtkPolyDataReader.h>
 #include <vtkPolyDataWriter.h>
 
+#include <iostream>
 #include <iterator>
 
 
@@ -12,7 +13,7 @@ int main (int argc, char *argv[])
 	PARSE_ARGS;
     
     if(inputMesh.compare("") == 0){
-        cout<<"type --help to learn how to use this program."<<endl;
+        std::cout<<"type --help to learn how to use this program."<<std::endl;
         return 1;
     }
 

--- a/CLI/SurfaceFeaturesExtractor/surfacefeaturesextractor.hxx
+++ b/CLI/SurfaceFeaturesExtractor/surfacefeaturesextractor.hxx
@@ -1,5 +1,6 @@
 #include "surfacefeaturesextractor.h"
 #include <vtkDoubleArray.h>
+#include <iostream>
 #include <sstream>
 #include <vtkObjectFactory.h>
 


### PR DESCRIPTION
Add missing #include <iostream> and qualify bare cout/endl with std:: in surfacefeaturesextractor.cxx to fix implicit iostream dependency.

See: https://discourse.vtk.org/t/important-update-standard-iostream-availability-from-vtk/16171